### PR TITLE
Print prestop logs to pod logs and extend readme with configmap approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Instead of extending the buildkit docker image, it's also possible to mount the 
         type: RollingUpdate
         rollingUpdate:
           maxUnavailable: 0
+      template:
         spec:
           terminationGracePeriodSeconds: 1200
           containers:

--- a/buildkit-prestop.sh
+++ b/buildkit-prestop.sh
@@ -42,8 +42,12 @@ times=0
 
 # Print logs both locally as in pod logs
 print_logs() {
-    echo $1
-    echo "PreStop Hook: $1" >> /proc/1/fd/1
+    # If we're running in a Kubernetes pod, write logs to stdout of the container
+    if [ -n "$KUBERNETES_SERVICE_HOST" ]; then
+        echo "PreStop Hook: $1" >> /proc/1/fd/1
+    else
+        echo "$1"
+    fi
 }
 
 # Function to print a message conditionally based on DEBUG environment variable

--- a/buildkit-prestop.sh
+++ b/buildkit-prestop.sh
@@ -40,14 +40,20 @@ REQUIRED_CHECK_COUNT=$((WAIT_UNTIL_NO_BUILDS_SEEN_FOR_X_SECONDS * 1000 / CHECK_F
 # How many consecutive times we've seen no running builds
 times=0
 
+# Print logs both locally as in pod logs
+print_logs() {
+    echo $1
+    echo "PreStop Hook: $1" >> /proc/1/fd/1
+}
+
 # Function to print a message conditionally based on DEBUG environment variable
 print_debug() {
     if [ -n "$DEBUG" ]; then
-        echo "$1"
+        print_logs "$1"
     fi
 }
 
-echo "Waiting for build processes to finish..."
+print_logs "Waiting for build processes to finish..."
 
 # Loop until we see zero active connections REQUIRED_CHECK_COUNT consecutive times
 while true; do
@@ -64,4 +70,4 @@ while true; do
     usleep $CHECK_FREQUENCY_MS"000"  # Sleep for CHECK_FREQUENCY_MS milliseconds before checking again
 done
 
-echo "All build processes seem to have stopped. Exiting now."
+print_logs "All build processes seem to have stopped. Exiting now."


### PR DESCRIPTION
Small change to print the prestop logs also in the pod logs